### PR TITLE
Patch so no_censoring() doesn't crash through upper.tri()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,7 +3,8 @@
 ^\.Rproj\.user$
 ^ROADMAP$
 ^update_remotes\.sh$
-^CMakeLists.txt$
+^CMakeLists\.txt$
+^\.travis\.yml$
 ^build/.*$
 ^.*\.kdev4$
 ^\.kdev4/*$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^ROADMAP$
+^README\.md$
 ^update_remotes\.sh$
 ^CMakeLists\.txt$
 ^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: r
+cache: packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: r
+r: bioc-devel
 cache: packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: r
 r: bioc-devel
+pandoc_version: 1.16  # nbconvert installs pandocfilters 1.4 which needs this
 cache: packages
 addons:
   apt:
@@ -12,7 +13,7 @@ before_install:
   - tlmgr install mweights
   - tlmgr install sourcesanspro
   - tlmgr install sourcecodepro
-before_script:
+before_script:  # build vignette in advance to get useful errors
   - cd vignettes
   - jupyter nbconvert --template destiny.tplx --to latex Diffusion-Maps.ipynb
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ addons:
     packages:
       - python3-pip
 before_install:
+  - pip3 install -U pip
   - pip3 install jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ cache: packages
 addons:
   apt:
     packages:
-      - jupyter-nbconvert
-      - jupyter-notebook
+      - python3-pip
+before_install:
+  - pip3 install jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_install:
   - tlmgr install ly1
   - tlmgr install mweights
   - tlmgr install sourcesanspro
+  - tlmgr install sourcecodepro

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ before_install:
   - tlmgr install mweights
   - tlmgr install sourcesanspro
   - tlmgr install sourcecodepro
+before_script:
+  - cd vignettes
+  - jupyter nbconvert --template destiny.tplx --to latex Diffusion-Maps.ipynb
+  - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ cache: packages
 addons:
   apt:
     packages:
-    	- jupyter-nbconvert
-    	- jupyter-notebook
+      - jupyter-nbconvert
+      - jupyter-notebook

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   apt:
     packages:
       - python3-pip
+      - texlive-fonts-extra
 before_install:
   - pip3 install --user -U pip
   - pip3 install --user jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ addons:
     packages:
       - python3-pip
 before_install:
-  - pip3 install -U pip
-  - pip3 install jupyter
+  - pip3 install --user -U pip
+  - pip3 install --user jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
   apt:
     packages:
       - python3-pip
-      - texlive-fonts-extra
 before_install:
   - pip3 install --user -U pip
   - pip3 install --user jupyter
+  - tlmgr install sourcesanspro

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ addons:
 before_install:
   - pip3 install --user -U pip
   - pip3 install --user jupyter
+  - tlmgr install ly1
+  - tlmgr install mweights
   - tlmgr install sourcesanspro

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: r
 r: bioc-devel
 cache: packages
+addons:
+  apt:
+    packages:
+    	- jupyter-nbconvert
+    	- jupyter-notebook

--- a/R/diffusionmap.r
+++ b/R/diffusionmap.r
@@ -348,7 +348,7 @@ no_censoring <- function(dists, sigma, cb = invisible) {
 	} else {
 		# TODO: optimize local sigma no-censoring case
 		stopifnot(d2@uplo == 'U')
-		mask <- d2 != 0 & upper.tri(dists)
+		mask <- d2 != 0 & upper.tri.sparse(dists)
 		m <- function(mat) suppressMessages(as(mat, 'dsCMatrix')[mask])  # suppress warning about "inefficient .M.sub.i.logical"
 		
 		S1 <- m(tcrossprod(Matrix(sigma)))

--- a/R/utils.r
+++ b/R/utils.r
@@ -101,3 +101,10 @@ runs <- function(vec) {
 	enc$values <- make.unique(enc$values, '_')
 	inverse.rle(enc)
 }
+
+upper.tri.sparse<-function(x,diag=FALSE){
+# Works just like upper.tri() but doesn't forcibly coerce large 'sparseMatrix' back to 'matrix'
+	if (diag)
+        row(x) <= col(x)
+    else row(x) < col(x)
+}

--- a/R/utils.r
+++ b/R/utils.r
@@ -102,9 +102,9 @@ runs <- function(vec) {
 	inverse.rle(enc)
 }
 
-upper.tri.sparse<-function(x,diag=FALSE){
+upper.tri.sparse <- function(x,diag = FALSE){
 # Works just like upper.tri() but doesn't forcibly coerce large 'sparseMatrix' back to 'matrix'
 	if (diag)
-        row(x) <= col(x)
-    else row(x) < col(x)
+		row(x) <= col(x)
+	else row(x) < col(x)
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+destiny
+=======
+
+An R package for diffusion maps, with additional features for large-scale and single cell data.
+
+builds
+------
+
+- [![Travis](https://travis-ci.org/theislab/destiny.svg?branch=master)](https://travis-ci.org/theislab/destiny) – Travis
+- [![Bioconductor stable](http://bioconductor.org/shields/build/release/bioc/destiny.svg)](http://bioconductor.org/packages/destiny/) – Bioconductor stable
+- [![Bioconductor devel](http://bioconductor.org/shields/build/devel/bioc/destiny.svg)](http://bioconductor.org/packages/devel/destiny) – Bioconductor devel

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ builds
 ------
 
 - [![Travis](https://travis-ci.org/theislab/destiny.svg?branch=master)](https://travis-ci.org/theislab/destiny) – Travis
-- [![Bioconductor stable](http://bioconductor.org/shields/build/release/bioc/destiny.svg)](http://bioconductor.org/packages/destiny/) – Bioconductor stable
-- [![Bioconductor devel](http://bioconductor.org/shields/build/devel/bioc/destiny.svg)](http://bioconductor.org/packages/devel/destiny) – Bioconductor devel
+- [![Bioconductor stable](http://bioconductor.org/shields/build/release/bioc/destiny.svg)](http://bioconductor.org/checkResults/release/bioc-LATEST/destiny/) – Bioconductor stable
+- [![Bioconductor devel](http://bioconductor.org/shields/build/devel/bioc/destiny.svg)](http://bioconductor.org/checkResults/devel/bioc-LATEST/destiny/) – Bioconductor devel

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ destiny
 
 An R package for diffusion maps, with additional features for large-scale and single cell data.
 
+- [ICB project](https://www.helmholtz-muenchen.de/icb/destiny)
+- [Bioconductor package](http://bioconductor.org/packages/destiny)
+- [Bioinformatics paper](https://doi.org/10.1093/bioinformatics/btv715)
+
 builds
 ------
 


### PR DESCRIPTION
upper.tri() forcibly coerces input to a base matrix() using as.matrix().  This can be memory limiting for large sparse matrices. as.matrix() is not needed in upper.tri() to accomplish the goals of creating the mask in destiny.  As such this patch defines upper.tri.sparse() in R/utils.r with exactly the same implementation as upper.tri() without the call to as.matrix().  This is replaced in R/diffusionmap.r and allows destiny to proceed on an otherwise large 10x genomics single cell dataset (>150K cells) on a 32 Gb machine. Thanks for destiny.  Great package!